### PR TITLE
Bug-fix links in translated module

### DIFF
--- a/components/AuthController.php
+++ b/components/AuthController.php
@@ -57,4 +57,35 @@ abstract class AuthController extends CController
 
 		return $name;
 	}
+	
+	
+	/**
+	 * Returns the authorization item type controller-name as an (untranslated) string.
+	 * @param string $type the item type (0=operation, 1=task, 2=role).
+	 * @throws CException if the item type is invalid.
+	 */	
+	public function getItemTypeController($type)
+	{
+		switch ($type)
+		{
+			case CAuthItem::TYPE_OPERATION:
+				$controller = 'operation';
+				break;
+
+			case CAuthItem::TYPE_TASK:
+				$controller = 'task';
+				break;
+
+			case CAuthItem::TYPE_ROLE:
+				$controller = 'role';
+				break;
+
+			default:
+				throw new CException('Auth item type "' . $type . '" is valid.');
+		}
+
+		return $controller;
+	}		
+	
+	
 }

--- a/widgets/AuthItemDescriptionColumn.php
+++ b/widgets/AuthItemDescriptionColumn.php
@@ -41,7 +41,7 @@ class AuthItemDescriptionColumn extends AuthItemColumn
 		$controller = $this->grid->getController();
 
 		echo CHtml::link($data['item']->description,
-				array('/auth/' . $controller->getItemTypeText($data['item']->type) . '/view', 'name' => $data['name']),
+				array('/auth/' . $controller->getItemTypeController($data['item']->type) . '/view', 'name' => $data['name']),
 				array( 'class' => $linkCssClass));
 	}
 }


### PR DESCRIPTION
In the AuthItemDescriptionColumn the AuthItem controller-name for the links is now derived from a seperated function in the authController, instead of using the (translated) AuthItem Name. This prevents the links from running dead in case of a translation.
