### PR TITLE
Russian translation fixes

### DIFF
--- a/messages/ru/main.php
+++ b/messages/ru/main.php
@@ -46,7 +46,7 @@ return array (
 	'No {type} found.' => 'Не найдено {type}',
 	'Page not found.' => 'Страница не найдена',
 	'Permissions' => 'Права',
-	'Permissions granted by this item' => 'Права предоставлены данным элементом',
+	'Permissions granted by this item' => 'Права предоставляемые элементом',
 	'Permissions that inherit this item' => 'Права которые наследует данный элемент',
 	'Remove' => 'Удалить',
 	'Revoke' => 'Отнять',


### PR DESCRIPTION
`Права предоставлены данным элементом`
Звучит двусмысленно. Можно понять как `предоставлены кем`, хотя на самом деле означает `предоставлены для`
