### PR TITLE
composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
     "keywords": ["yii", "auth"],
     "homepage": "http://www.yiiframework.com/extension/auth/",
     "type": "yii-extension",
-    "license": "-",
+    "license": "BSD-3-Clause",
     "authors": [
         {
-            "name": "C. Niska",
-            "email": "-",
+            "name": "Christoffer Niska",
+            "email": "ChristofferNiska@gmail.com",
             "homepage": "http://cniska.net"
         }
     ],

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "crisu83/yii-auth",
+    "description": "Web UI for Yii's authorization manager.",
+    "keywords": ["yii", "auth"],
+    "homepage": "http://www.yiiframework.com/extension/auth/",
+    "type": "yii-extension",
+    "license": "-",
+    "authors": [
+        {
+            "name": "C. Niska",
+            "email": "-",
+            "homepage": "http://cniska.net"
+        }
+    ],
+    "require": {
+        "crisu83/yii-bootstrap": "2.*"
+    }
+}


### PR DESCRIPTION
fixes #25

But you should update a few values, composer.phar validate output:

./composer.json is valid, but with a few warnings
See http://getcomposer.org/doc/04-schema.md for details on the schema
License "-" is not a valid SPDX license identifier, see http://www.spdx.org/licenses/ if you use an open license
authors.0.email : invalid value (-), must be a valid email address
