### PR TITLE
Fix administrator assignment-listing

### DIFF
--- a/widgets/AuthAssignmentItemsColumn.php
+++ b/widgets/AuthAssignmentItemsColumn.php
@@ -33,7 +33,7 @@ class AuthAssignmentItemsColumn extends AuthAssignmentColumn
 		/* @var $am CAuthManager|AuthBehavior */
 		$am = Yii::app()->getAuthManager();
 
-		if (Yii::app()->user->isAdmin)
+		if (in_array($data->{$this->nameColumn}, Yii::app()->authManager->admins))
 			echo Yii::t('AuthModule.main', 'Administrator');
 		else
 		{

--- a/widgets/AuthAssignmentItemsColumn.php
+++ b/widgets/AuthAssignmentItemsColumn.php
@@ -33,7 +33,7 @@ class AuthAssignmentItemsColumn extends AuthAssignmentColumn
 		/* @var $am CAuthManager|AuthBehavior */
 		$am = Yii::app()->getAuthManager();
 
-		if (in_array($data->{$this->nameColumn}, Yii::app()->authManager->admins))
+		if (in_array($data->{$this->nameColumn}, $am->admins))
 			echo Yii::t('AuthModule.main', 'Administrator');
 		else
 		{


### PR DESCRIPTION
When the logged-in-user is configured as Admin, all users are listed as beeing Administrator on assignments view.

This PR changes the check for Admin-role from logged-in-user to the user in the list.
