### PR TITLE
Update widgets/AuthAssignmentItemsColumn.php

### DIFF
--- a/widgets/AuthAssignmentItemsColumn.php
+++ b/widgets/AuthAssignmentItemsColumn.php
@@ -33,7 +33,7 @@ class AuthAssignmentItemsColumn extends AuthAssignmentColumn
 		/* @var $am CAuthManager|AuthBehavior */
 		$am = Yii::app()->getAuthManager();
 
-		if (in_array($data->name, $am->admins))
+		if (in_array($data->{$this->nameColumn}, $am->admins))
 			echo Yii::t('AuthModule.main', 'Administrator');
 		else
 		{


### PR DESCRIPTION
When used in protected/config/main.php:
'userNameColumn' => 'username', // the name of the user name column.
There was an error about property User.Name
Change this piece of code, prevents the error.
