### PR TITLE
AuthBehavior optimizations to reduce number of queries.

### DIFF
--- a/components/AuthBehavior.php
+++ b/components/AuthBehavior.php
@@ -20,7 +20,9 @@ class AuthBehavior extends CBehavior
 	private $_items = array();
 
 	/**
-	 * @return array of all items with their parents and children
+	 * Return thee parents and children of specific item or all items
+	 * @param string $itemName name of the item.
+	 * @return array
 	 */
 	public function getItems($itemName=null)
 	{
@@ -32,8 +34,8 @@ class AuthBehavior extends CBehavior
 
 	/**
 	 * Sets the parents of specific item
-	 *
-	 * @return array
+	 * @param string $itemName name of the item.
+	 * @param array $parents
 	 */
 	public function setItemParents($itemName, $parents)
 	{
@@ -42,8 +44,8 @@ class AuthBehavior extends CBehavior
 
 	/**
 	 * Sets the children of specific item
-	 *
-	 * @return array
+	 * @param string $itemName name of the item.
+	 * @param array $children
 	 */
 	public function setItemChildren($itemName, $children)
 	{
@@ -52,7 +54,7 @@ class AuthBehavior extends CBehavior
 
 	/**
 	 * Gets the parents of specific item if exists
-	 *
+	 * @param string $itemName name of the item.
 	 * @return array
 	 */
 	public function getParents($itemName)
@@ -66,7 +68,7 @@ class AuthBehavior extends CBehavior
 
 	/**
 	 * Gets the children of specific item if exists
-	 *
+	 * @param string $itemName name of the item.
 	 * @return array
 	 */
 	public function getChildren($itemName)


### PR DESCRIPTION
There are two main issues:

The first one is that we get all items and iterate over them to get the relations. This one can be suppressed with a plain query to the items child table and getting just the relations between the items.

The second problem is in the displaying the results table:

Method: `AuthItemTypeColumn::renderDataCellContent()`

``` php
$am = Yii::app()->getAuthManager();
$labelType = $this->active || $am->hasParent($this->itemName, $data['name']) || $am->hasChild($this->itemName, $data['name']) ? 'info' : '';
```

Here we call `hasParent()` or `hasChild()` methods which triggers `getItemPermissions()` and  `getAuthItem()` methods which queries the database once for each column.(`AuthItemTypeColumn`, `AuthItemRemoveColumn`, `AuthItemDescriptionColumn`). This happens on every row of the result table and leads to poor performance.

If we cache the items and their relations when we get the descendants and ancestors this process gets very clean with limited number of queries.
