### PR TITLE
 Fix url missing module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "crisu83/yii-auth",
+    "name": "boox/ws-fork/crisu83/yii-auth",
     "description": "Web UI for the authorization manager of Yii PHP framework.",
     "keywords": ["yii", "authentication", "rbac"],
     "type": "library",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "boox/ws-fork/crisu83/yii-auth",
-    "description": "Web UI for the authorization manager of Yii PHP framework.",
+    "description": "Fork of crisu83/yii-auth",
     "keywords": ["yii", "authentication", "rbac"],
     "type": "library",
     "license": "BSD-3-Clause",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "boox/ws-fork/crisu83/yii-auth",
-    "description": "Fork of crisu83/yii-auth",
+    "description": " Fork of crisu83/yii-aut, Web UI for the authorization manager of Yii PHP framework.",
     "keywords": ["yii", "authentication", "rbac"],
     "type": "library",
     "license": "BSD-3-Clause",

--- a/widgets/AuthItemDescriptionColumn.php
+++ b/widgets/AuthItemDescriptionColumn.php
@@ -44,7 +44,7 @@ class AuthItemDescriptionColumn extends AuthItemColumn
 
         echo CHtml::link(
             $data['item']->description,
-            array('/auth/' . $controller->getItemControllerId($data['item']->type) . '/view', 'name' => $data['name']),
+            array($controller->getItemControllerId($data['item']->type) . '/view', 'name' => $data['name']),
             array('class' => $linkCssClass)
         );
     }


### PR DESCRIPTION
Remove the absolute path generation and use the relative path instead.
The preceding slash also prevented Yii generate URL without considering
the module of the controller.

https://jira.aminocom.com/browse/BPLAT-4219